### PR TITLE
Added CredentialProvider for username and password login

### DIFF
--- a/Web/_tests_/index.test.tsx
+++ b/Web/_tests_/index.test.tsx
@@ -58,6 +58,10 @@ describe('Render Index Page', () => {
     }));
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('Check for Manage Cards', async () => {
     const { container } = render(<Home />);
 

--- a/Web/prisma/schema.prisma
+++ b/Web/prisma/schema.prisma
@@ -29,6 +29,7 @@ model User {
   name          String?
   email         String?   @unique
   emailVerified DateTime?
+  password    String?
   image         String?
   sessions      Session[]
   admin      Boolean  @default(true)

--- a/Web/src/components/Auth.tsx
+++ b/Web/src/components/Auth.tsx
@@ -25,9 +25,10 @@ function Auth({ children, admin }) {
     async function fetchData() {
       try {
         if (
-          !process.env.NODE_ENV ||
-          process.env.NODE_ENV === 'development' ||
-          process.env.ENVIRONMENT === 'development'
+          process.env.SETDEV &&
+          (!process.env.NODE_ENV ||
+            process.env.NODE_ENV === 'development' ||
+            process.env.ENVIRONMENT === 'development')
         ) {
           devSession.current = await currentSession();
           if (

--- a/Web/src/constants/nextAuthOptions.ts
+++ b/Web/src/constants/nextAuthOptions.ts
@@ -452,6 +452,7 @@ export const options = {
       try {
         if (
           email !== null &&
+          email !== undefined && 
           Object.prototype.hasOwnProperty.call(email, 'verificationRequest')
         ) {
           const email: string = (user.email as string).trim().toLowerCase();

--- a/Web/src/helper/session.ts
+++ b/Web/src/helper/session.ts
@@ -9,7 +9,10 @@ import { getSession } from 'next-auth/react';
  * @return a Promise containing a Result
  */
 export const currentSession = async (): Promise<Session | null> => {
-  if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') {
+  if (
+    process.env.SETDEV &&
+    (!process.env.NODE_ENV || process.env.NODE_ENV === 'development')
+  ) {
     let session: Session | null = null;
     session = {
       expires: '1',

--- a/Web/src/helper/sessionServer.ts
+++ b/Web/src/helper/sessionServer.ts
@@ -15,7 +15,10 @@ export const currentSession = async (
   context: any = null,
   server: boolean = true,
 ): Promise<Session | null> => {
-  if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') {
+  if (
+    process.env.SETDEV &&
+    (!process.env.NODE_ENV || process.env.NODE_ENV === 'development')
+  ) {
     let session: Session | null = null;
     session = {
       expires: '1',

--- a/Web/src/pages/signin-test.tsx
+++ b/Web/src/pages/signin-test.tsx
@@ -1,32 +1,31 @@
 import React, { useState, useEffect, useRef } from 'react';
 import {
+  Flex,
   Box,
-  Button,
   FormControl,
   FormLabel,
-  Flex,
-  Heading,
   Input,
   Stack,
-  Spinner,
+  Button,
+  Heading,
   Text,
+  Spinner,
 } from '@chakra-ui/react';
 import { signIn } from 'next-auth/react';
 import { checkerString } from '@helper/common';
-import { useRouter } from 'next/router'
 
 /**
  * This component renders the signin page that is displayed to the user
  * if there is no previous session found.
  */
-export default function SignIn(props: Promise<{ data: string }>) {
-  const router = useRouter()
-
+export default function SignInTest(props: Promise<{ data: string }>) {
   const [loading, setLoading] = useState(false);
   const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
   const [url, setURL] = useState('http://localhost:3000'); // default
 
   const emailDB = useRef('');
+  const passwordDB = useRef('');
   const [errorMsg, setError] = useState('');
 
   useEffect(() => {
@@ -41,28 +40,27 @@ export default function SignIn(props: Promise<{ data: string }>) {
 
   const handleSubmit = async (event: { preventDefault: () => void }) => {
     event.preventDefault();
-    if (checkerString(emailDB.current) && emailDB.current.includes('@')) {
+    if (
+      checkerString(emailDB.current) &&
+      emailDB.current.includes('@') &&
+      checkerString(passwordDB.current)
+    ) {
       try {
         setError('');
         setLoading(true);
-        await signIn('email', {
-          email: email,
+        await signIn('credentials', {
+          username: emailDB.current,
+          password: passwordDB.current,
           callbackUrl: `${url}/`,
         });
-
         return true;
       } catch (error) {
         return false;
       }
     } else {
-      setError('Please enter a valid email');
+      setError('Please enter a valid email or enter a password');
       return false;
     }
-  };
-
-  const handleClick = async (event: { preventDefault: () => void }) => {
-    event.preventDefault();
-    router.push('/signin-test');
   };
 
   return (
@@ -85,11 +83,27 @@ export default function SignIn(props: Promise<{ data: string }>) {
                 <FormLabel>Email address</FormLabel>
                 <Input
                   type='email'
+                  name='email'
                   placeholder='test@gmail.com'
                   size='lg'
+                  value={email}
                   onChange={(event) => {
                     setEmail(event.currentTarget.value);
                     emailDB.current = event.currentTarget.value;
+                  }}
+                />
+              </FormControl>
+              <FormControl id='password'>
+                <FormLabel>Password</FormLabel>
+                <Input
+                  type='password'
+                  name='password'
+                  placeholder=''
+                  size='lg'
+                  value={password}
+                  onChange={(event) => {
+                    setPassword(event.currentTarget.value);
+                    passwordDB.current = event.currentTarget.value;
                   }}
                 />
               </FormControl>
@@ -108,6 +122,7 @@ export default function SignIn(props: Promise<{ data: string }>) {
               </Stack>
             </Stack>
           </form>
+
           {loading && (
             <Stack spacing={10} mt={5}>
               <Stack align='center'>
@@ -119,19 +134,6 @@ export default function SignIn(props: Promise<{ data: string }>) {
             </Stack>
           )}
         </Box>
-
-        <Button
-                  type='submit'
-                  bg='blue.200'
-                  disabled={loading}
-                  color='white'
-                  _hover={{
-                    bg: 'blue.300',
-                  }}
-                  onClick={handleClick}
-                >
-            Test User Login
-          </Button>
       </Stack>
     </Flex>
   );

--- a/Web/src/pages/signin.tsx
+++ b/Web/src/pages/signin.tsx
@@ -13,14 +13,14 @@ import {
 } from '@chakra-ui/react';
 import { signIn } from 'next-auth/react';
 import { checkerString } from '@helper/common';
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/router';
 
 /**
  * This component renders the signin page that is displayed to the user
  * if there is no previous session found.
  */
 export default function SignIn(props: Promise<{ data: string }>) {
-  const router = useRouter()
+  const router = useRouter();
 
   const [loading, setLoading] = useState(false);
   const [email, setEmail] = useState('');
@@ -121,17 +121,17 @@ export default function SignIn(props: Promise<{ data: string }>) {
         </Box>
 
         <Button
-                  type='submit'
-                  bg='blue.200'
-                  disabled={loading}
-                  color='white'
-                  _hover={{
-                    bg: 'blue.300',
-                  }}
-                  onClick={handleClick}
-                >
-            Test User Login
-          </Button>
+          type='submit'
+          bg='blue.200'
+          disabled={loading}
+          color='white'
+          _hover={{
+            bg: 'blue.300',
+          }}
+          onClick={handleClick}
+        >
+          Test User Login
+        </Button>
       </Stack>
     </Flex>
   );


### PR DESCRIPTION
Enhancements:
- Added new Credential provider from Next-Auth to facilitate automated testing software, which is not possible using passwordless authentication.
- CredentialProvider will only be usable on pre-authorized accounts such as the Test User created as passwordless authentication is still the preferred method of authentication

Improvement
- Bug fixes over Provider and added new button to redirect users to new signin page for Testing purposes